### PR TITLE
Fix forageable spawning

### DIFF
--- a/MTN2/MapData/Spawn/Forage.cs
+++ b/MTN2/MapData/Spawn/Forage.cs
@@ -16,7 +16,7 @@ namespace MTN2.MapData {
         public Forage(string MapName) : base(MapName) { }
 
         public override void AddAtPoint(Vector2 Point, Spawn SItem) {
-            Map.dropObject(new SObject(Point, SItem.ItemId, null, false, true, false, true));
+            Map.dropObject(new SObject(Point, SItem.ItemId, null, false, true, false, true), Point * 64f, StardewValley.Game1.viewport, true, null);
         }
 
         public override void SpawnAll(int Attempts) {


### PR DESCRIPTION
While the method does run with the other overload, something related to the tile location is wrong, thus resulting in forageables either not being placed correctly or them not being placed at all. The latter option seems more likely.

Simply, this is how the base game handles it.